### PR TITLE
Associate property mappers to CLI commands

### DIFF
--- a/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
+++ b/quarkus/deployment/src/main/java/org/keycloak/quarkus/deployment/KeycloakProcessor.java
@@ -461,7 +461,7 @@ class KeycloakProcessor {
             Map<String, String> configProperties = dbConfig.getDefaultDatasource().getConfigProperties();
 
             for (Entry<String, String> dbConfigProperty : configProperties.entrySet()) {
-                PropertyMapper mapper = PropertyMappers.getMapper(dbConfigProperty.getKey());
+                PropertyMapper<?> mapper = PropertyMappers.getMapper(dbConfigProperty.getKey());
 
                 if (mapper == null) {
                     continue;
@@ -515,7 +515,7 @@ class KeycloakProcessor {
     }
 
     private void putPersistedProperty(Properties properties, String name) {
-        PropertyMapper mapper = PropertyMappers.getMapper(name);
+        PropertyMapper<?> mapper = PropertyMappers.getMapper(name);
         ConfigValue value = null;
 
         if (mapper == null) {

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/AbstractCommand.java
@@ -19,6 +19,7 @@ package org.keycloak.quarkus.runtime.cli.command;
 
 import static org.keycloak.quarkus.runtime.Messages.cliExecutionError;
 
+import org.keycloak.quarkus.runtime.configuration.mappers.PropertyMapper;
 import picocli.CommandLine;
 import picocli.CommandLine.Model.CommandSpec;
 import picocli.CommandLine.Spec;
@@ -34,5 +35,14 @@ public abstract class AbstractCommand {
 
     protected void executionError(CommandLine cmd, String message, Throwable cause) {
         cliExecutionError(cmd, message, cause);
+    }
+
+    /**
+     * Get property mappers associated to particular command
+     *
+     * @return array of property mappers
+     */
+    public PropertyMapper<?>[] getMappers() {
+        return new PropertyMapper[]{};
     }
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/ShowConfig.java
@@ -142,7 +142,7 @@ public final class ShowConfig extends AbstractCommand implements Runnable {
             value = configValue.getValue();
         }
 
-        PropertyMapper mapper = PropertyMappers.getMapper(property);
+        PropertyMapper<?> mapper = PropertyMappers.getMapper(property);
 
         if (mapper != null && mapper.isRunTime()) {
             value = getRuntimeProperty(property).orElse(value);

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Tools.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/cli/command/Tools.java
@@ -22,6 +22,6 @@ import picocli.CommandLine.Command;
 @Command(name = "tools",
         description = "Utilities for use and interaction with the server.",
         subcommands = {Completion.class})
-public class Tools {
+public class Tools extends AbstractCommand {
 
 }

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/ConfigArgsConfigSource.java
@@ -108,7 +108,7 @@ public class ConfigArgsConfigSource extends PropertiesConfigSource {
 
                 properties.put(key, value);
 
-                PropertyMapper mapper = PropertyMappers.getMapper(key);
+                PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
                 if (mapper != null) {
                     String to = mapper.getTo();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/Configuration.java
@@ -98,7 +98,7 @@ public final class Configuration {
     }
 
     public static String getMappedPropertyName(String key) {
-        PropertyMapper mapper = PropertyMappers.getMapper(key);
+        PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
         if (mapper == null) {
             return key;

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KcEnvConfigSource.java
@@ -44,7 +44,7 @@ public class KcEnvConfigSource extends EnvConfigSource {
             if (key.startsWith(kcPrefix)) {
                 properties.put(key, value);
 
-                PropertyMapper mapper = PropertyMappers.getMapper(key);
+                PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
                 if (mapper != null) {
                     String to = mapper.getTo();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/KeycloakPropertiesConfigSource.java
@@ -144,7 +144,7 @@ public class KeycloakPropertiesConfigSource extends AbstractLocationConfigSource
         Map<String, String> result = new HashMap<>(properties.size());
         properties.keySet().forEach(k -> {
             String key = transformKey(k);
-            PropertyMapper mapper = PropertyMappers.getMapper(key);
+            PropertyMapper<?> mapper = PropertyMappers.getMapper(key);
 
             //TODO: remove explicit checks for spi and feature options once we have proper support in our config mappers
             if (mapper != null

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMapper.java
@@ -38,7 +38,7 @@ import org.keycloak.quarkus.runtime.configuration.MicroProfileConfigProvider;
 
 public class PropertyMapper<T> {
 
-    static PropertyMapper IDENTITY = new PropertyMapper(
+    static PropertyMapper<?> IDENTITY = new PropertyMapper(
             new OptionBuilder<String>(null, String.class).build(),
             null,
             null,
@@ -104,7 +104,7 @@ public class PropertyMapper<T> {
 
                 if (parentValue == null) {
                     // parent value not explicitly set, try to resolve the default value set to the parent property
-                    PropertyMapper parentMapper = PropertyMappers.getMapper(parentKey);
+                    PropertyMapper<?> parentMapper = PropertyMappers.getMapper(parentKey);
 
                     if (parentMapper != null && parentMapper.getDefaultValue().isPresent()) {
                         parentValue = ConfigValue.builder().withValue(parentMapper.getDefaultValue().get().toString()).build();

--- a/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
+++ b/quarkus/runtime/src/main/java/org/keycloak/quarkus/runtime/configuration/mappers/PropertyMappers.java
@@ -38,11 +38,10 @@ public final class PropertyMappers {
         MAPPERS.addAll(StoragePropertyMappers.getMappers());
         MAPPERS.addAll(ClassLoaderPropertyMappers.getMappers());
         MAPPERS.addAll(SecurityPropertyMappers.getMappers());
-        MAPPERS.addAll(ExportPropertyMappers.getMappers());
     }
 
     public static ConfigValue getValue(ConfigSourceInterceptorContext context, String name) {
-        PropertyMapper mapper = MAPPERS.getOrDefault(name, PropertyMapper.IDENTITY);
+        PropertyMapper<?> mapper = MAPPERS.getOrDefault(name, PropertyMapper.IDENTITY);
         return mapper.getConfigValue(name, context);
     }
 
@@ -51,7 +50,7 @@ public final class PropertyMappers {
             return true;
         }
 
-        PropertyMapper mapper = MAPPERS.get(name);
+        PropertyMapper<?> mapper = MAPPERS.get(name);
         boolean isBuildTimeProperty = mapper == null ? false : mapper.isBuildTime();
 
         return isBuildTimeProperty
@@ -73,17 +72,17 @@ public final class PropertyMappers {
         return name.startsWith("kc.features");
     }
 
-    public static Map<OptionCategory, List<PropertyMapper>> getRuntimeMappers() {
+    public static Map<OptionCategory, List<PropertyMapper<?>>> getRuntimeMappers() {
         return MAPPERS.getRuntimeMappers();
     }
 
-    public static Map<OptionCategory, List<PropertyMapper>> getBuildTimeMappers() {
+    public static Map<OptionCategory, List<PropertyMapper<?>>> getBuildTimeMappers() {
         return MAPPERS.getBuildTimeMappers();
     }
 
     public static String formatValue(String property, String value) {
         property = removeProfilePrefixIfNeeded(property);
-        PropertyMapper mapper = getMapper(property);
+        PropertyMapper<?> mapper = getMapper(property);
 
         if (mapper != null && mapper.isMask()) {
             return VALUE_MASK;
@@ -100,28 +99,32 @@ public final class PropertyMappers {
         return property;
     }
 
-    public static PropertyMapper getMapper(String property) {
+    public static PropertyMapper<?> getMapper(String property) {
         if (property.startsWith("%")) {
             return MAPPERS.get(property.substring(property.indexOf('.') + 1));
         }
         return MAPPERS.get(property);
     }
 
-    public static Collection<PropertyMapper> getMappers() {
+    public static Collection<PropertyMapper<?>> getMappers() {
         return MAPPERS.values();
     }
 
-    public static boolean isSupported(PropertyMapper mapper) {
+    public static boolean isSupported(PropertyMapper<?> mapper) {
         return mapper.getCategory().getSupportLevel().equals(ConfigSupportLevel.SUPPORTED);
     }
 
-    private static class MappersConfig extends HashMap<String, PropertyMapper> {
+    public static void addMappers(PropertyMapper<?>... mappers) {
+        MAPPERS.addAll(mappers);
+    }
 
-        private Map<OptionCategory, List<PropertyMapper>> buildTimeMappers = new EnumMap<>(OptionCategory.class);
-        private Map<OptionCategory, List<PropertyMapper>> runtimeTimeMappers = new EnumMap<>(OptionCategory.class);
+    private static class MappersConfig extends HashMap<String, PropertyMapper<?>> {
 
-        public void addAll(PropertyMapper[] mappers) {
-            for (PropertyMapper mapper : mappers) {
+        private final Map<OptionCategory, List<PropertyMapper<?>>> buildTimeMappers = new EnumMap<>(OptionCategory.class);
+        private final Map<OptionCategory, List<PropertyMapper<?>>> runtimeTimeMappers = new EnumMap<>(OptionCategory.class);
+
+        public void addAll(PropertyMapper<?>[] mappers) {
+            for (PropertyMapper<?> mapper : mappers) {
                 super.put(mapper.getTo(), mapper);
                 super.put(mapper.getFrom(), mapper);
                 super.put(mapper.getCliFormat(), mapper);
@@ -135,29 +138,29 @@ public final class PropertyMappers {
             }
         }
 
-        private void addMapperByStage(PropertyMapper mapper, Map<OptionCategory, List<PropertyMapper>> mappers) {
+        private void addMapperByStage(PropertyMapper<?> mapper, Map<OptionCategory, List<PropertyMapper<?>>> mappers) {
             mappers.computeIfAbsent(mapper.getCategory(),
-                    new Function<OptionCategory, List<PropertyMapper>>() {
+                    new Function<OptionCategory, List<PropertyMapper<?>>>() {
                         @Override
-                        public List<PropertyMapper> apply(OptionCategory c) {
+                        public List<PropertyMapper<?>> apply(OptionCategory c) {
                             return new ArrayList<>();
                         }
                     }).add(mapper);
         }
 
         @Override
-        public PropertyMapper put(String key, PropertyMapper value) {
+        public PropertyMapper<?> put(String key, PropertyMapper<?> value) {
             if (containsKey(key)) {
                 throw new IllegalArgumentException("Duplicated mapper for key [" + key + "]");
             }
             return super.put(key, value);
         }
 
-        public Map<OptionCategory, List<PropertyMapper>> getRuntimeMappers() {
+        public Map<OptionCategory, List<PropertyMapper<?>>> getRuntimeMappers() {
             return runtimeTimeMappers;
         }
 
-        public Map<OptionCategory, List<PropertyMapper>> getBuildTimeMappers() {
+        public Map<OptionCategory, List<PropertyMapper<?>>> getBuildTimeMappers() {
             return buildTimeMappers;
         }
     }

--- a/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
+++ b/quarkus/tests/integration/src/main/java/org/keycloak/it/utils/RawKeycloakDistribution.java
@@ -121,8 +121,8 @@ public final class RawKeycloakDistribution implements KeycloakDistribution {
             throw new RuntimeException("Failed to start the server", cause);
         } finally {
             if (arguments.contains(Build.NAME) && removeBuildOptionsAfterBuild) {
-                for (List<PropertyMapper> mappers : PropertyMappers.getBuildTimeMappers().values()) {
-                    for (PropertyMapper mapper : mappers) {
+                for (List<PropertyMapper<?>> mappers : PropertyMappers.getBuildTimeMappers().values()) {
+                    for (PropertyMapper<?> mapper : mappers) {
                         removeProperty(mapper.getFrom().substring(3));
                     }
                 }


### PR DESCRIPTION
@ahus1 With these changes, we can directly associate particular property mappers with CLI commands.

@ahus1 @vmuzikar @pedroigor WDYT?

JFYI, it's not polished solution ;]

I can create a separate PR for this.

You can see here the properties are available only for the export command: 
![Screenshot from 2023-03-03 19-27-59](https://user-images.githubusercontent.com/38039883/222801028-441e23eb-431d-42e9-a075-5c8a8af721cc.png)

We could also make other changes in order to avoid polluting the `Picocli.java` class such as determining whether run the build before executing the command. As we already know what particular command we're handling; we don't have to ask for it multiple times. 


